### PR TITLE
update ProxySettingManager

### DIFF
--- a/SpechtLite/AppDelegate.swift
+++ b/SpechtLite/AppDelegate.swift
@@ -3,18 +3,19 @@ import Cocoa
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
     var menuController: MenuBarController!
-    
+
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         LoggerManager.setUp()
         PreferenceManager.setUp()
         UpdateManager.setUp()
         ProxySettingManager.setUp()
         ProfileManager.setUp()
-        
+
         menuController = MenuBarController()
     }
-    
+
     func applicationWillTerminate(_ aNotification: Notification) {
         ProfileManager.stopProxyServer()
+        ProxySettingManager.clear()
     }
 }

--- a/SpechtLite/Manager/ProxySettingManager.swift
+++ b/SpechtLite/Manager/ProxySettingManager.swift
@@ -3,19 +3,31 @@ import ReactiveSwift
 
 class ProxySettingManager {
     static let setAsSystemProxy: MutableProperty<Bool> = MutableProperty(false)
-    
+
     static func setUp() {
         setAsSystemProxy.producer.combineLatest(with: ProfileManager.currentProxyPort.producer).startWithValues { enabled, port in
             var port = port
             if !enabled {
                 port = nil
             }
-            
+
             if !ProxyHelper.install() {
                 Utils.alertError("Failed to install helper script to set up system proxy.")
             } else {
                 if !ProxyHelper.setUpSystemProxy(port: port) {
                     Utils.alertError("Failed to set up system proxy.")
+                }
+            }
+        }
+    }
+
+    static func clear() {
+        if setAsSystemProxy.value {
+            if !ProxyHelper.install() {
+                Utils.alertError("Failed to install helper script to clear system proxy.")
+            } else {
+                if !ProxyHelper.setUpSystemProxy(port: nil) {
+                    Utils.alertError("Failed to clear system proxy.")
                 }
             }
         }


### PR DESCRIPTION
Currently, if you set SpechtLite as system proxy, after you exit SpechtLite you can not access the Internet. Because the system proxy is still there. I add a function ProxySettingManager.clear() to clear system proxy when you exit SpechtLite.